### PR TITLE
Fix missing bot config check

### DIFF
--- a/backend/src/providers/openai-format-provider.ts
+++ b/backend/src/providers/openai-format-provider.ts
@@ -169,6 +169,12 @@ export class OpenAIFormatProvider implements BaseProvider {
     
     const apiKey = this.botConfig.api_key;
     const baseUrl = this.botConfig.base_url;
+    if (!baseUrl || !apiKey) {
+      const configError = new Error('Bot configuration missing base_url or api_key') as OpenRouterError;
+      configError.type = 'provider_error';
+      configError.status = 400;
+      throw configError;
+    }
     const apiPath = this.botConfig.custom_api_path || '/chat/completions';
     
     const controller = new AbortController();


### PR DESCRIPTION
## Summary
- ensure `base_url` and `api_key` exist before fetching

## Testing
- `npm run build:backend`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68528367fd2c832ea5bd17162879da6e