### PR TITLE
Improve timeout error reporting

### DIFF
--- a/backend/src/providers/openai-format-provider.ts
+++ b/backend/src/providers/openai-format-provider.ts
@@ -23,6 +23,9 @@ interface OpenRouterError extends Error {
   status: number;
 }
 
+// Timeout for provider requests in milliseconds
+const REQUEST_TIMEOUT_MS = 10000; // 10 second timeout
+
 /**
  * OpenAI Format Provider implementation
  * This class implements the BaseProvider interface for providers using OpenAI-compatible API format
@@ -178,7 +181,7 @@ export class OpenAIFormatProvider implements BaseProvider {
     const apiPath = this.botConfig.custom_api_path || '/chat/completions';
     
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS); // Abort if request takes too long
 
     try {
       const response = await fetch(`${baseUrl}${apiPath}`, {
@@ -279,6 +282,7 @@ export class OpenAIFormatProvider implements BaseProvider {
           const timeoutError = error as OpenRouterError;
           timeoutError.type = 'timeout_error';
           timeoutError.status = 408;
+          timeoutError.message = `Request exceeded the configured timeout of ${REQUEST_TIMEOUT_MS / 1000} seconds. Consider increasing the timeout.`;
           throw timeoutError;
         }
         // If it's already an OpenRouterError, re-throw it


### PR DESCRIPTION
## Summary
- add `REQUEST_TIMEOUT_MS` constant
- include helpful message for aborted requests

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528ead6440832e808c149dc3fc5044