### PR TITLE
Add API timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ flowchart TD
 3. Configure environment variables:
    - Copy `backend/.dev.vars.example` to `backend/.dev.vars` and fill in the values.
      `OPENROUTER_BASE_URL` specifies the default OpenRouter API endpoint and
-     `OPENROUTER_FREE_KEY` provides a fallback API key. The backend uses these
-     values whenever a bot configuration does not include its own `base_url` or
-     `api_key`.
+     `OPENROUTER_FREE_KEY` provides a fallback API key. `API_TIMEOUT_MS` sets the
+     default timeout (in milliseconds) for provider requests. These values are
+     used whenever a bot configuration does not include its own `base_url`,
+     `api_key`, or `timeout_ms`.
    - Configure Cloudflare Worker settings in `backend/wrangler.toml`
 
 4. Build asset:
@@ -125,7 +126,7 @@ y-gui/
 - `npm run deploy`: Deploy the backend to Cloudflare Workers
 - `npm run test`: Run tests
 
-Before running the development server, copy `backend/.dev.vars.example` to `backend/.dev.vars` and set your environment variables. `OPENROUTER_BASE_URL` and `OPENROUTER_FREE_KEY` act as fallback credentials when a bot configuration omits `base_url` or `api_key`.
+Before running the development server, copy `backend/.dev.vars.example` to `backend/.dev.vars` and set your environment variables. `OPENROUTER_BASE_URL` and `OPENROUTER_FREE_KEY` act as fallback credentials when a bot configuration omits `base_url` or `api_key`. `API_TIMEOUT_MS` defines the default request timeout used when `timeout_ms` is not specified in a bot configuration.
 
 
 When starting with `npm run dev`, the browser will open to `/`. This page automatically
@@ -147,6 +148,7 @@ y-gui supports multiple bot configurations with the following properties:
 - Custom API Path
 - Max Tokens
 - Reasoning Effort
+- Timeout (ms)
 
 ## 🔗 MCP Server Configuration
 

--- a/backend/.dev.vars.example
+++ b/backend/.dev.vars.example
@@ -5,3 +5,4 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CLENDAR_REDIRECT_URI=http://localhost:4000/callback/google-calendar
 GOOGLE_GMAIL_REDIRECT_URI=http://localhost:4000/callback/gmail
+API_TIMEOUT_MS=30000

--- a/backend/src/api/chat-completions.ts
+++ b/backend/src/api/chat-completions.ts
@@ -50,6 +50,12 @@ export async function handleChatCompletions(request: Request, env: Env, userPref
         resultBotConfig.api_key = env.OPENROUTER_FREE_KEY;
         resultBotConfig.base_url = env.OPENROUTER_BASE_URL;
       }
+      if (!resultBotConfig.timeout_ms) {
+        const envTimeout = parseInt(env.API_TIMEOUT_MS || '0', 10);
+        if (envTimeout) {
+          resultBotConfig.timeout_ms = envTimeout;
+        }
+      }
       console.log('Bot config:', resultBotConfig);
 
       // Get the provider

--- a/backend/src/providers/openai-format-provider.ts
+++ b/backend/src/providers/openai-format-provider.ts
@@ -178,7 +178,8 @@ export class OpenAIFormatProvider implements BaseProvider {
     const apiPath = this.botConfig.custom_api_path || '/chat/completions';
     
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+    const timeoutMs = this.botConfig.timeout_ms ?? 30000;
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
       const response = await fetch(`${baseUrl}${apiPath}`, {

--- a/backend/src/worker-configuration.d.ts
+++ b/backend/src/worker-configuration.d.ts
@@ -12,4 +12,5 @@ export interface Env {
     GOOGLE_CLIENT_SECRET: string;
     GOOGLE_CLENDAR_REDIRECT_URI: string;
     GOOGLE_GMAIL_REDIRECT_URI: string;
+    API_TIMEOUT_MS: string;
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -65,6 +65,11 @@ export interface BotConfig {
   custom_api_path?: string;
   max_tokens?: number;
   reasoning_effort?: string;
+  /**
+   * Timeout in milliseconds for API requests. If omitted, the backend will
+   * use the default configured via the API_TIMEOUT_MS environment variable.
+   */
+  timeout_ms?: number;
 }
 
 export interface McpServerConfig {


### PR DESCRIPTION
## Summary
- allow configuring request timeout via `timeout_ms` in bot config
- expose `API_TIMEOUT_MS` environment variable
- default to 30s when not specified
- document the new option in README and example environment file

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68528ea6ebc0832ea3262b9439806ea0