### PR TITLE
Streamline settings access

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -61,7 +61,7 @@ export default function App() {
                 <Route path="/" element={<NewChatRedirect />} />
                 <Route path="/chat/:id" element={<ChatView />} />
                 <Route path="/share/:id" element={<ChatView />} />
-                <Route path="/settings" element={<Navigate to="/settings/general" replace />} />
+                <Route path="/settings" element={<Navigate to="/settings/bots" replace />} />
                 <Route path="/settings/:section" element={<Settings />} />
                 <Route path="/callback/:service" element={<OAuthCallback />} />
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -56,29 +56,8 @@ const Header: React.FC = () => {
 		return () => clearInterval(interval);
 	}, [storageKey, selectedBot]);
 	const location = useLocation();
-	const { isDarkMode, theme, setTheme } = useTheme();
-	const [showDropdown, setShowDropdown] = useState(false);
-	const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-	const [showSearchWindow, setShowSearchWindow] = useState(false);
-	const dropdownRef = useRef<HTMLDivElement>(null);
-	const mobileMenuRef = useRef<HTMLDivElement>(null);
-	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-	// Handle clicking outside the dropdown or mobile menu
-	useEffect(() => {
-		function handleClickOutside(event: MouseEvent) {
-			if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-				setShowDropdown(false);
-			}
-			if (mobileMenuRef.current && !mobileMenuRef.current.contains(event.target as Node)) {
-				setMobileMenuOpen(false);
-			}
-		}
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => {
-			document.removeEventListener("mousedown", handleClickOutside);
-		};
-	}, []);
+        const { isDarkMode } = useTheme();
+        const [showSearchWindow, setShowSearchWindow] = useState(false);
 
 	// Close SearchWindow on ESC key press
 	useEffect(() => {
@@ -131,87 +110,16 @@ const Header: React.FC = () => {
 							<path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
 						</svg>
 					</button>
-					{/* Right side dropdown */}
-					<div className="relative" ref={dropdownRef}>
-						<button
-							onMouseEnter={() => setShowDropdown(true)}
-							onMouseLeave={() => {
-								timeoutRef.current = setTimeout(() => setShowDropdown(false), 100);
-							}}
-							className={`${isDarkMode ? 'text-gray-400 hover:text-white hover:bg-gray-800' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'} p-2 rounded-full transition-colors flex items-center`}
-						>
-                                        {/* Menu button */}
-                                        <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
-                                        </svg>
-						</button>
-
-						{showDropdown && (
-							<div
-								onMouseEnter={() => {
-									if (timeoutRef.current) {
-										clearTimeout(timeoutRef.current);
-										timeoutRef.current = null;
-									}
-									setShowDropdown(true);
-								}}
-								onMouseLeave={() => setShowDropdown(false)}
-								className={`absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'} ring-1 ring-black ring-opacity-5 z-50`}
-							>
-								{/* Theme options */}
-								<div className="px-4 py-2 text-sm">
-									<p className="font-medium mb-2">Theme</p>
-									<div className="flex flex-col space-y-2">
-										<button
-											onClick={() => setTheme('light')}
-											className={`flex items-center space-x-2 ${theme === 'light' ? 'text-blue-500' : ''}`}
-										>
-											<svg className="h-4 w-4 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
-												<path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
-											</svg>
-											<span>Light</span>
-										</button>
-										<button
-											onClick={() => setTheme('dark')}
-											className={`flex items-center space-x-2 ${theme === 'dark' ? 'text-blue-500' : ''}`}
-										>
-											<svg className="h-4 w-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-												<path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-											</svg>
-											<span>Dark</span>
-										</button>
-										<button
-											onClick={() => setTheme('system')}
-											className={`flex items-center space-x-2 ${theme === 'system' ? 'text-blue-500' : ''}`}
-										>
-											<svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-												<path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-											</svg>
-											<span>System</span>
-										</button>
-									</div>
-								</div>
-
-								{/* Settings option */}
-								<button
-									onClick={() => {
-										navigate('/settings');
-										setShowDropdown(false);
-									}}
-									className={`block w-full text-left px-4 py-2 text-sm ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'} border-b border-gray-200 dark:border-gray-700`}
-								>
-									<div className="flex items-center space-x-2">
-										<svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
-											<path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-										</svg>
-										<span>Settings</span>
-									</div>
-								</button>
-
-							</div>
-						)}
-					</div>
+                                        <button
+                                                onClick={() => navigate('/settings/bots')}
+                                                className={`${isDarkMode ? 'text-gray-400 hover:text-white hover:bg-gray-800' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'} p-2 rounded-full transition-colors flex items-center`}
+                                                aria-label="Settings"
+                                        >
+                                                <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                                </svg>
+                                        </button>
 				</div>
 			</div>
 

--- a/frontend/src/components/Settings/Settings.tsx
+++ b/frontend/src/components/Settings/Settings.tsx
@@ -12,12 +12,12 @@ interface SettingsProps {
 export const Settings: React.FC<SettingsProps> = ({ }) => {
   const navigate = useNavigate();
   const { section } = useParams<{ section: string }>();
-  const { isDarkMode, setTheme } = useTheme();
+  const { isDarkMode } = useTheme();
 
-  // Validate section parameter and default to 'general' if invalid
-  const activeSection = (section === 'general' || section === 'bots' || section === 'mcp-servers' || section === 'integrations')
+  // Validate section parameter and default to 'bots' if invalid
+  const activeSection = (section === 'bots' || section === 'mcp-servers' || section === 'integrations')
     ? section
-    : 'general';
+    : 'bots';
 
   // Redirect if section is invalid
   useEffect(() => {
@@ -92,21 +92,6 @@ export const Settings: React.FC<SettingsProps> = ({ }) => {
               isDarkMode ? 'bg-gray-800 border border-gray-700' : 'bg-white border border-gray-200'
             }`}>
               <Link
-                to="/settings/general"
-                onClick={() => setIsMobileMenuOpen(false)}
-                className={`block w-full text-left px-4 py-2 text-sm ${
-                  activeSection === 'general'
-                    ? isDarkMode
-                      ? 'bg-gray-700 text-white'
-                      : 'bg-blue-50 text-blue-600'
-                    : isDarkMode
-                      ? 'text-gray-300 hover:bg-gray-700'
-                      : 'text-gray-700 hover:bg-gray-100'
-                }`}
-              >
-                General
-              </Link>
-              <Link
                 to="/settings/bots"
                 onClick={() => setIsMobileMenuOpen(false)}
                 className={`block w-full text-left px-4 py-2 text-sm ${
@@ -175,22 +160,6 @@ export const Settings: React.FC<SettingsProps> = ({ }) => {
             <ul>
               <li className="mb-1">
                 <Link
-                  to="/settings/general"
-                  className={`block w-full text-left px-3 py-2 rounded-md ${
-                    activeSection === 'general'
-                      ? isDarkMode
-                        ? 'bg-gray-800 text-white font-medium'
-                        : 'bg-blue-50 text-blue-600 font-medium'
-                      : isDarkMode
-                        ? 'text-gray-300 hover:bg-gray-800'
-                        : 'text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  General
-                </Link>
-              </li>
-              <li className="mb-1">
-                <Link
                   to="/settings/bots"
                   className={`block w-full text-left px-3 py-2 rounded-md ${
                     activeSection === 'bots'
@@ -243,72 +212,6 @@ export const Settings: React.FC<SettingsProps> = ({ }) => {
 
         {/* Main content */}
         <div className="flex-1 p-4 sm:p-8 overflow-y-auto">
-          {/* General settings section */}
-          {activeSection === 'general' && (
-            <div className="mb-12">
-              <h2 className={`text-xl sm:text-2xl font-medium mb-6 ${isDarkMode ? 'text-white' : 'text-gray-900'} sm:hidden`}>General</h2>
-              <h2 className={`hidden sm:block text-2xl font-medium mb-6 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>General</h2>
-
-              <div className="max-w-3xl">
-                {/* User Information Section */}
-                <div className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'} py-4`}>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h3 className={`text-lg font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>User Information</h3>
-                      <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Your account details</p>
-                    </div>
-                    <div>
-                      {userInfoLoading && <span className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Loading...</span>}
-                      {userInfoError && <span className="text-sm text-red-500">Error loading user data</span>}
-                    </div>
-                  </div>
-
-                  {userInfo && (
-                    <div className="mt-4">
-                      <div className="flex items-center">
-                        {userInfo.picture && (
-                          <img
-                            src={userInfo.picture}
-                            alt="Profile"
-                            className="w-12 h-12 rounded-full mr-4"
-                          />
-                        )}
-                        <div>
-                          <h4 className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>{userInfo.name || 'User'}</h4>
-                          <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{userInfo.email}</p>
-                          <p className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>ID: {userInfo.sub}</p>
-                          <p className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>Prefix: {userInfo.userPrefix}</p>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-								{/* Theme */}
-                <div className={`border-b ${isDarkMode ? 'border-gray-700' : 'border-gray-200'} py-4`}>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h3 className={`text-lg font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>Theme</h3>
-                      <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Select your preferred color scheme</p>
-                    </div>
-                    <div className="flex items-center space-x-3">
-                      <span className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Light</span>
-                      <label className="relative inline-flex items-center cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={isDarkMode}
-                          onChange={(e) => setTheme(e.target.checked ? 'dark' : 'light')}
-                          className="sr-only peer"
-                        />
-                        <div className={`w-11 h-6 ${isDarkMode ? 'bg-blue-600' : 'bg-gray-200'} rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all`}></div>
-                      </label>
-                      <span className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Dark</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
 
           {/* Bot settings section */}
           {activeSection === 'bots' && (


### PR DESCRIPTION
## Summary
- simplify settings routes
- remove dropdown menu from header, add direct settings icon
- clean up settings page by removing theme switcher and general tab

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6852aa5b6b78832e9575f2a2453a922c