### PR TITLE
Fix hanging backend streams

### DIFF
--- a/backend/src/api/chat-completions.ts
+++ b/backend/src/api/chat-completions.ts
@@ -43,7 +43,9 @@ export async function handleChatCompletions(request: Request, env: Env, userPref
       const bots = await botRepository.getBots();
       const botConfig = bots.find(bot => bot.name === botName);
       if (!botConfig) {
-        return new Response('Bot not found', { status: 404, headers: corsHeaders });
+        await writer.write(encoder.encode(`data: {"error": "Bot not found"}\n\n`));
+        await writer.close();
+        return;
       }
       let resultBotConfig = botConfig;
       if (!resultBotConfig.api_key || !resultBotConfig.base_url) {

--- a/backend/src/api/tool.ts
+++ b/backend/src/api/tool.ts
@@ -40,7 +40,9 @@ export async function handleToolConfirmation(request: Request, env: Env, userPre
       const bots = await botRepository.getBots();
       const botConfig = bots.find(bot => bot.name === botName);
       if (!botConfig) {
-        return new Response('Bot not found', { status: 404, headers: corsHeaders });
+        await writer.write(encoder.encode(`data: {"error": "Bot not found"}\n\n`));
+        await writer.close();
+        return;
       }
 
       // Execute the tool directly

--- a/frontend/src/components/ChatView/ChatView.tsx
+++ b/frontend/src/components/ChatView/ChatView.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { useBot } from '../../contexts/BotContext';
 import { useToc } from '../../contexts/TocContext';
 import { useMcp } from '../../contexts/McpContext';
-import { useApi } from '../../utils/api';
+import { useApi, useAuthenticatedSWR } from '../../utils/api';
 import { getMcpServers } from '../../utils/storage';
 import { Chat, Message, McpServerConfig } from '@shared/types';
 import { mutate } from 'swr';


### PR DESCRIPTION
## Summary
- close SSE streams when bot config isn't found

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685396411fd8832e9f9449c222e3feef