### PR TITLE
Fix hanging backend streams

### DIFF
--- a/backend/src/api/chat-router.ts
+++ b/backend/src/api/chat-router.ts
@@ -18,7 +18,7 @@ router.all('*', async (c) => {
     body: c.req.raw.body
   });
   
-  return handleChatsRequest(request, c.env, c.get('userPrefix'));
+  return handleChatsRequest(request, c.env, c.get('userPrefix'), c.executionCtx);
 });
 
 export default router;

--- a/backend/src/api/chat.ts
+++ b/backend/src/api/chat.ts
@@ -5,8 +5,14 @@ import { handleChatCompletions } from './chat-completions';
 import { handleSelectResponse } from './chat-select';
 import { generateUniqueId } from '../utils/chat';
 import { Env } from 'worker-configuration';
+import type { ExecutionContext } from '@cloudflare/workers-types';
 
-export async function handleChatsRequest(request: Request, env: Env, userPrefix?: string): Promise<Response> {
+export async function handleChatsRequest(
+  request: Request,
+  env: Env,
+  userPrefix?: string,
+  ctx?: ExecutionContext
+): Promise<Response> {
   const chatRepository = new ChatMemoryRepository(userPrefix);
   const url = new URL(request.url);
   const path = url.pathname;
@@ -81,7 +87,7 @@ export async function handleChatsRequest(request: Request, env: Env, userPrefix?
 
     // Send message to chat (completions endpoint)
     if (path === '/api/chat/completions' && request.method === 'POST') {
-      return handleChatCompletions(request, env, userPrefix);
+      return handleChatCompletions(request, env, userPrefix, ctx);
     }
 
     if (path === '/api/chat/select-response' && request.method === 'POST') {

--- a/backend/src/api/tool-router.ts
+++ b/backend/src/api/tool-router.ts
@@ -18,7 +18,7 @@ router.all('*', async (c) => {
     body: c.req.raw.body
   });
   
-  return handleToolConfirmation(request, c.env, c.get('userPrefix'));
+  return handleToolConfirmation(request, c.env, c.get('userPrefix'), c.executionCtx);
 });
 
 export default router;

--- a/backend/src/api/tool.ts
+++ b/backend/src/api/tool.ts
@@ -6,13 +6,19 @@ import { IntegrationMemoryRepository } from '../repository/memory/integration-me
 import { Message } from '../../../shared/types';
 import { createMessage } from 'src/utils/message';
 import { Env } from 'worker-configuration';
+import type { ExecutionContext } from '@cloudflare/workers-types';
 
 /**
  * Handle tool execution confirmation
  * This endpoint allows clients to confirm or cancel tool execution
  * and directly executes the tool if confirmed
  */
-export async function handleToolConfirmation(request: Request, env: Env, userPrefix?: string): Promise<Response> {
+export async function handleToolConfirmation(
+  request: Request,
+  env: Env,
+  userPrefix?: string,
+  ctx?: ExecutionContext
+): Promise<Response> {
   // Parse request body
   interface ConfirmationRequest {
     botName: string;
@@ -28,7 +34,7 @@ export async function handleToolConfirmation(request: Request, env: Env, userPre
   const writer = writable.getWriter();
   const encoder = new TextEncoder();
   
-  (async () => {
+  const task = (async () => {
     try {
       // Initialize repositories and MCP manager
       const mcpServerRepository = new McpServerMemoryRepository(env, userPrefix);
@@ -40,7 +46,9 @@ export async function handleToolConfirmation(request: Request, env: Env, userPre
       const bots = await botRepository.getBots();
       const botConfig = bots.find(bot => bot.name === botName);
       if (!botConfig) {
-        return new Response('Bot not found', { status: 404, headers: corsHeaders });
+        await writer.write(encoder.encode(`data: {"error": "Bot not found"}\n\n`));
+        await writer.close();
+        return;
       }
 
       // Execute the tool directly
@@ -64,6 +72,8 @@ export async function handleToolConfirmation(request: Request, env: Env, userPre
       writer.abort(error);
     }
   })();
+
+  ctx?.waitUntil(task);
   
   // Return the streaming response
   return new Response(readable, {

--- a/frontend/src/components/ChatView/ChatView.tsx
+++ b/frontend/src/components/ChatView/ChatView.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { useBot } from '../../contexts/BotContext';
 import { useToc } from '../../contexts/TocContext';
 import { useMcp } from '../../contexts/McpContext';
-import { useApi } from '../../utils/api';
+import { useApi, useAuthenticatedSWR } from '../../utils/api';
 import { getMcpServers } from '../../utils/storage';
 import { Chat, Message, McpServerConfig } from '@shared/types';
 import { mutate } from 'swr';


### PR DESCRIPTION
## Summary
- close SSE streams when bot config isn't found
- propagate ExecutionContext to streaming endpoints to avoid hanging promises

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685396411fd8832e9f9449c222e3feef