### PR TITLE
Simplify bot config and remove remote APIs

### DIFF
--- a/backend/src/api/bot.ts
+++ b/backend/src/api/bot.ts
@@ -11,17 +11,6 @@ export async function handleBotRequest(request: Request, env: Env, userPrefix?: 
   const botName = pathParts.length > 3 ? pathParts[3] : null;
 
   try {
-    // Get bot configurations
-    if (path === '/api/bots' && request.method === 'GET') {
-      const bots = await botRepo.getBots();
-      const publicBots = bots.map(({ name, model }) => ({ name, model }));
-      return new Response(JSON.stringify(publicBots), {
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
-    }
     // Add a new bot
     if (path === '/api/bot' && request.method === 'POST') {
       const botConfig: BotConfig = await request.json();

--- a/backend/src/api/mcp-server.ts
+++ b/backend/src/api/mcp-server.ts
@@ -11,21 +11,6 @@ export async function handleMcpServerRequest(request: Request, env: Env, userPre
   const serverName = pathParts.length > 3 ? pathParts[3] : null;
 
   try {
-    // Get MCP server configurations
-    if (path === '/api/mcp-servers' && request.method === 'GET') {
-      const servers = await mcpRepo.getMcpServers();
-      const publicServers = servers.map(({ name, url, need_confirm }) => ({
-        name,
-        url,
-        need_confirm
-      }));
-      return new Response(JSON.stringify(publicServers), {
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
-    }
     // Add a new MCP server
     if (path === '/api/mcp-server' && request.method === 'POST') {
       const mcpServerConfig: McpServerConfig = await request.json();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,10 +2,8 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { Env } from './worker-configuration';
 import chatRouter from './api/chat-router';
-import botRouter from './api/bot-router';
 import shareRouter from './api/share-router';
 import toolRouter from './api/tool-router';
-import mcpServerRouter from './api/mcp-server-router';
 import { integrationRouter } from './api/integration';
 import { handleApiDocs } from './openapi';
 
@@ -48,11 +46,7 @@ app.use('/api/*', async (c, next) => {
 app.route('/api/share', shareRouter);
 app.route('/api/chats', chatRouter);
 app.route('/api/chat', chatRouter);
-app.route('/api/bots', botRouter);
-app.route('/api/bot', botRouter);
 app.route('/api/tool', toolRouter);
-app.route('/api/mcp-servers', mcpServerRouter);
-app.route('/api/mcp-server', mcpServerRouter);
 app.route('/api/integrations', integrationRouter);
 app.route('/api/integration', integrationRouter);
 

--- a/backend/src/openapi/handler.ts
+++ b/backend/src/openapi/handler.ts
@@ -3,8 +3,6 @@ import { swaggerUiHtml } from './ui';
 import { schemas } from './schemas';
 import { chatPaths } from './paths/chat';
 import { toolPaths } from './paths/tool';
-import { botPaths } from './paths/bot';
-import { mcpServerPaths } from './paths/mcp-server';
 
 // Handler for OpenAPI documentation endpoints
 export async function handleApiDocs(request: Request): Promise<Response> {
@@ -32,8 +30,6 @@ export async function handleApiDocs(request: Request): Promise<Response> {
       paths: {
         ...chatPaths,
         ...toolPaths,
-        ...botPaths,
-        ...mcpServerPaths,
       },
     };
 

--- a/backend/src/openapi/index.ts
+++ b/backend/src/openapi/index.ts
@@ -3,6 +3,4 @@ export { handleApiDocs } from './handler';
 export { schemas } from './schemas';
 export { chatPaths } from './paths/chat';
 export { toolPaths } from './paths/tool';
-export { botPaths } from './paths/bot';
-export { mcpServerPaths } from './paths/mcp-server';
 export { swaggerUiHtml } from './ui';

--- a/frontend/src/components/ChatView/ChatView.tsx
+++ b/frontend/src/components/ChatView/ChatView.tsx
@@ -6,6 +6,7 @@ import { useToc } from '../../contexts/TocContext';
 import { useMcp } from '../../contexts/McpContext';
 import { useApi, useAuthenticatedSWR } from '../../utils/api';
 import { Chat, Message, McpServerConfig } from '@shared/types';
+import { DEFAULT_MCP_SERVERS } from '../../config';
 import { mutate } from 'swr';
 import useSWR, { SWRConfiguration } from 'swr';
 import { useMcpStatus } from '../../hooks/useMcpStatus';
@@ -116,23 +117,8 @@ export default function ChatView() {
         swrConfig
       );
 
-  // Load MCP servers from backend in regular mode
-  const [mcpServers, setMcpServers] = useState<McpServerConfig[] | undefined>(undefined);
-  useEffect(() => {
-    async function fetchServers() {
-      if (isSharedMode) return;
-      try {
-        const res = await fetch('/api/mcp-servers');
-        if (res.ok) {
-          const data = (await res.json()) as McpServerConfig[];
-          setMcpServers(data);
-        }
-      } catch (err) {
-        console.error('Failed to fetch MCP servers', err);
-      }
-    }
-    fetchServers();
-  }, [isSharedMode]);
+  // Use locally configured MCP servers
+  const [mcpServers] = useState<McpServerConfig[]>(DEFAULT_MCP_SERVERS);
 
   // Debug selectedBot changes
   useEffect(() => {
@@ -959,8 +945,6 @@ export default function ChatView() {
           <MessageInput
             message={message}
             setMessage={setMessage}
-            selectedBot={selectedBot}
-            setSelectedBot={setSelectedBot}
             isLoading={isStreaming}
             handleSubmit={handleSubmit}
             isFixed={true}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -10,51 +10,6 @@ import SearchWindow from '../SearchWindow';
 const Header: React.FC = () => {
         const { toggleToc } = useToc();
         const navigate = useNavigate();
-	const [selectedBot, setSelectedBot] = useState<string | null>(null);
-
-	// Get the current path
-	const currentPath = window.location.pathname;
-
-	// Get the localStorage key based on current path
-	const storageKey = currentPath === '/'
-		? 'home_page_selected_bot'
-		: `chat_${currentPath.split('/').pop()}_selectedBot`;
-
-	// Watch for changes in localStorage
-	useEffect(() => {
-		// Initial load
-		setSelectedBot(localStorage.getItem(storageKey));
-
-		// Create storage event listener
-		const handleStorageChange = (e: StorageEvent) => {
-			if (e.key === storageKey) {
-				setSelectedBot(e.newValue);
-			}
-		};
-
-		// Add event listener
-		window.addEventListener('storage', handleStorageChange);
-
-		// Cleanup
-		return () => {
-			window.removeEventListener('storage', handleStorageChange);
-		};
-	}, [storageKey]);
-
-	// Watch for direct changes to localStorage
-	useEffect(() => {
-		const checkLocalStorage = () => {
-			const currentValue = localStorage.getItem(storageKey);
-			if (currentValue !== selectedBot) {
-				setSelectedBot(currentValue);
-			}
-		};
-
-		// Check every 100ms for changes
-		const interval = setInterval(checkLocalStorage, 100);
-
-		return () => clearInterval(interval);
-	}, [storageKey, selectedBot]);
 	const location = useLocation();
         const { isDarkMode } = useTheme();
         const [showSearchWindow, setShowSearchWindow] = useState(false);
@@ -84,11 +39,7 @@ const Header: React.FC = () => {
                                                 className="flex items-center cursor-pointer"
                                                 onClick={() => navigate('/')}
                                         >
-                                                <img
-                                                        src="https://urva.co/wp-content/uploads/2022/02/urva_logo_outline.png"
-                                                        alt="URVA logo"
-                                                        className="h-8"
-                                                />
+                                                <Logo />
                                         </a>
 				</div>
 

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useBot } from '../contexts/BotContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { useApi } from '../utils/api';
 import MessageInput from './MessageInput';
+import { DEFAULT_BOT } from '../config';
 
 interface HomeProps {
 }
@@ -15,7 +15,6 @@ export default function Home({ }: HomeProps) {
 
   // New chat creation states
   const [newMessage, setNewMessage] = React.useState('');
-  const { selectedBot, setSelectedBot } = useBot();
   const [isCreatingChat, setIsCreatingChat] = React.useState(false);
   const [isProcessingMessage, setIsProcessingMessage] = React.useState(false);
 
@@ -23,8 +22,8 @@ export default function Home({ }: HomeProps) {
   const api = useApi();
 
   // Handle creating a new chat with a message
-  const handleNewChatWithMessage = async (content: string, botName: string) => {
-    if (!content.trim() || !botName) return;
+  const handleNewChatWithMessage = async (content: string) => {
+    if (!content.trim()) return;
 
     setIsCreatingChat(true);
 
@@ -37,7 +36,7 @@ export default function Home({ }: HomeProps) {
 
       // Store the message and bot in localStorage so ChatView can use it
       localStorage.setItem(`newChat_${id}_message`, content);
-      localStorage.setItem(`newChat_${id}_bot`, botName);
+      localStorage.setItem(`newChat_${id}_bot`, DEFAULT_BOT.name);
 
       // The ChatView component will detect this and handle the streaming
     } catch (error) {
@@ -60,17 +59,15 @@ export default function Home({ }: HomeProps) {
         {/* New Chat Input */}
 				<div className={`py-4`}>
 					{/* Assistant Avatar */}
-					<MessageInput
-						message={newMessage}
-						setMessage={setNewMessage}
-						selectedBot={selectedBot}
-						setSelectedBot={setSelectedBot}
-						isLoading={isCreatingChat || isProcessingMessage}
-						handleSubmit={async () => Promise.resolve()} // Not used since we're using onSendMessage
-						onSendMessage={handleNewChatWithMessage}
-						isFixed={false} // Don't fix this input to the bottom of the screen
-					/>
-				</div>
+                                        <MessageInput
+                                                message={newMessage}
+                                                setMessage={setNewMessage}
+                                                isLoading={isCreatingChat || isProcessingMessage}
+                                                handleSubmit={async () => Promise.resolve()} // Not used since we're using onSendMessage
+                                                onSendMessage={handleNewChatWithMessage}
+                                                isFixed={false} // Don't fix this input to the bottom of the screen
+                                        />
+                                </div>
 
       </main>
     </div>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_BOT = {
+  name: 'local-deepseek',
+  model: 'deepseek-r1:7b'
+};
+
+export const DEFAULT_MCP_SERVERS = [
+  {
+    name: 'default',
+    url: 'http://localhost:3000/mcp',
+    need_confirm: null,
+    token: null
+  }
+];

--- a/frontend/src/contexts/BotContext.tsx
+++ b/frontend/src/contexts/BotContext.tsx
@@ -1,5 +1,6 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import { BotConfig } from '@shared/types';
+import { DEFAULT_BOT } from '../config';
 
 
 interface BotContextType {
@@ -12,26 +13,8 @@ interface BotContextType {
 const BotContext = createContext<BotContextType | undefined>(undefined);
 
 export function BotProvider({ children }: { children: React.ReactNode }) {
-  const [bots, setBots] = useState<BotConfig[]>([]);
-  const [selectedBot, setSelectedBot] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    async function fetchBots() {
-      try {
-        const res = await fetch('/api/bots');
-        if (res.ok) {
-          const data = (await res.json()) as BotConfig[];
-          setBots(data);
-          if (!selectedBot && data.length > 0) {
-            setSelectedBot(data[0].name);
-          }
-        }
-      } catch (err) {
-        console.error('Failed to fetch bots', err);
-      }
-    }
-    fetchBots();
-  }, []);
+  const [bots, setBots] = useState<BotConfig[]>([DEFAULT_BOT]);
+  const [selectedBot, setSelectedBot] = useState<string | undefined>(DEFAULT_BOT.name);
 
   return (
     <BotContext.Provider value={{ bots, setBots, selectedBot, setSelectedBot }}>


### PR DESCRIPTION
## Summary
- drop routes for bot and mcp server listings
- trim OpenAPI definitions for those routes
- rely on a static bot and MCP server configuration on the frontend
- remove bot dropdown UI and enable sending messages without bot selection
- clean up header logo

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6853d079b230832eacc39171a4ea5e7a