### PR TITLE
Update header styling with URVA logo

### DIFF
--- a/frontend/src/components/ChatView/McpLogsDisplay.tsx
+++ b/frontend/src/components/ChatView/McpLogsDisplay.tsx
@@ -44,8 +44,8 @@ export default function McpLogsDisplay({ logs, isVisible, onClose, isDarkMode }:
 
   return (
     <div
-      className={`w-full sm:w-[80%] h-full overflow-x-hidden overflow-y-auto ${
-        isDarkMode ? 'bg-gray-900 text-gray-300' : 'bg-gray-50 text-gray-700'
+      className={`w-full sm:w-[80%] h-full overflow-x-hidden overflow-y-auto border shadow-md ${
+        isDarkMode ? 'bg-gray-900 text-gray-300 border-gray-700' : 'bg-white text-gray-800 border-gray-200'
       } sm:rounded-lg`}
       onScroll={(e) => e.stopPropagation()}
       onWheel={(e) => e.stopPropagation()}

--- a/frontend/src/components/ChatView/TableOfContents.tsx
+++ b/frontend/src/components/ChatView/TableOfContents.tsx
@@ -82,7 +82,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({
 
   return (
     <div
-      className={`w-full sm:w-[80%] h-full overflow-x-hidden overflow-y-auto ${isDarkMode ? 'bg-gray-900 text-gray-300' : 'bg-gray-50 text-gray-700'} sm:rounded-lg`}
+      className={`w-full sm:w-[80%] h-full overflow-x-hidden overflow-y-auto border shadow-md ${isDarkMode ? 'bg-gray-900 text-gray-300 border-gray-700' : 'bg-white text-gray-800 border-gray-200'} sm:rounded-lg`}
       onScroll={(e) => e.stopPropagation()}
       onWheel={(e) => e.stopPropagation()}
     >

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useToc } from '../../contexts/TocContext';
 import TocToggleButton from '../ChatView/TocToggleButton';
-import Logo from '../Logo';
 import SearchWindow from '../SearchWindow';
 
 
@@ -32,14 +31,18 @@ const Header: React.FC = () => {
 	}, [showSearchWindow]);
 
 	return (
-		<header className={`fixed top-0 z-40 w-screen h-16 sm:h-0 ${isDarkMode ? 'bg-[#1a1a1a] border-gray-800' : 'bg-white border-gray-100'} `}>
+                <header className="fixed top-0 z-40 w-screen h-16 bg-[#182144]">
 			<div className="flex items-center justify-between mx-4 mt-2 sm:mx-6 2xl:mx-8">
 				<div className="flex items-center space-x-8">
                                         <a
-                                                className="flex items-center cursor-pointer"
+                                                className="flex items-center cursor-pointer h-full"
                                                 onClick={() => navigate('/')}
                                         >
-                                                <Logo />
+                                                <img
+                                                        src="https://feetport-ssd.s3.ap-south-1.amazonaws.com/v2/678/fm/general/docs/urva%201.png"
+                                                        alt="URVA Logo"
+                                                        className="h-full w-auto"
+                                                />
                                         </a>
 				</div>
 


### PR DESCRIPTION
## Summary
- restore URVA logo in the header and set bar colour to `#182144`
- unify message list and MCP log panels with matching borders and shadows

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6853eaf61d30832eb1625bfa67d82f8d